### PR TITLE
feat: enhance message processing and gui

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,3 +6,15 @@
 
 ## Suggestions
 - Consider adding comprehensive unit tests for each module.
+- Implement full reflection and long-term memory modules.
+
+## Progress
+### Completed
+- Added GUI queue display and chaos log.
+- Discord bot now forwards all messages for analysis.
+
+### In Progress
+- Integrating real LLM models and database storage.
+
+### Next Steps
+- Expand engagement logic and persistence once LLM integration stabilizes.

--- a/main.py
+++ b/main.py
@@ -14,6 +14,7 @@ from modules.thoughts import summarize
 from modules.catch import CatchMemory
 from modules.fallback import handle_error
 from modules.dispatch import dispatch
+from modules.reflect import reflect
 from engage.engagement import should_respond, log_interaction
 from engage.database import Database
 
@@ -23,30 +24,43 @@ def start_services(config):
 
     ports = config["ports"]["dispatch"]
 
-    # Start Discord bot
-    threading.Thread(target=start_bot, args=(config.get("discord_token"), memory), daemon=True).start()
-
     # Start placeholder LLMs
     llm_intent = LocalLLM()
     llm_emotion = LocalLLM()
     llm_thoughts = LocalLLM()
-    for llm in (llm_intent, llm_emotion, llm_thoughts):
+    llm_reflect = LocalLLM()
+    for llm in (llm_intent, llm_emotion, llm_thoughts, llm_reflect):
         threading.Thread(target=llm.start, daemon=True).start()
 
     def process_message(user: str, message: str):
         try:
+            if memory.gui:
+                memory.gui.log_event(f"msg:{user}")
             intent = analyze_intent(message)
             emotion = analyze_emotion(message)
+            memory.enqueue(user, message, intent, emotion)
             if should_respond(user, message, intent, emotion):
                 thoughts = summarize(user, intent, emotion, llm_thoughts)
-                response = f"{user}: {thoughts}"
+                reflection = reflect(user, message, llm_reflect)
+                response = f"{user}: {thoughts} | reflect: {reflection}"
                 log_interaction(db, user, message, intent, emotion)
                 dispatch(response, ports)
+                if memory.gui:
+                    memory.gui.log_event(f"dispatch:{user}")
         except Exception as e:  # pragma: no cover
             handle_error(e)
 
+    # Start Discord bot
+    threading.Thread(
+        target=start_bot,
+        args=(config.get("discord_token"), memory, process_message),
+        daemon=True,
+    ).start()
+
     # Example of processing a placeholder message
     threading.Thread(target=process_message, args=("system", "hello"), daemon=True).start()
+
+    return memory
 
 
 def main():
@@ -58,10 +72,11 @@ def main():
     with open('config.json') as f:
         config = json.load(f)
 
-    start_services(config)
+    memory = start_services(config)
 
     if not args.no_gui:
-        gui = SystemGUI()
+        gui = SystemGUI(memory)
+        memory.bind_gui(gui)
         gui.run()
 
     if args.test:

--- a/modules/catch.py
+++ b/modules/catch.py
@@ -1,11 +1,54 @@
-"""Short-term memory cache module."""
+"""Short-term memory cache module.
+
+This module keeps a simple key-value store and a queue of recent
+messages.  The queue is used by the GUI to show how many messages are
+waiting to be processed and to display recent activity.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
 
 class CatchMemory:
-    def __init__(self):
-        self.store = {}
+    """In-memory storage for short-lived data."""
 
-    def remember(self, key: str, value):
+    def __init__(self, capacity: int = 1000):
+        self.store: Dict[str, Any] = {}
+        self.queue: List[Dict[str, Any]] = []
+        self.capacity = capacity
+        self.gui: Optional[Any] = None
+
+    # ------------------------------------------------------------------
+    # Key/value helpers
+    def remember(self, key: str, value: Any) -> None:
         self.store[key] = value
+        if self.gui:
+            self.gui.log_event(f"remember:{key}")
 
-    def recall(self, key: str):
+    def recall(self, key: str) -> Any:
         return self.store.get(key)
+
+    # ------------------------------------------------------------------
+    # Message queue helpers
+    def enqueue(self, user: str, message: str, intent: str, emotion: str) -> None:
+        """Add a message to the queue, respecting the capacity."""
+        entry = {
+            "user": user,
+            "message": message,
+            "intent": intent,
+            "emotion": emotion,
+        }
+        if len(self.queue) >= self.capacity:
+            self.queue.pop(0)
+        self.queue.append(entry)
+        if self.gui:
+            self.gui.display_message(entry)
+            self.gui.log_event(f"enqueue:{user}")
+
+    def bind_gui(self, gui: Any) -> None:
+        """Attach a GUI instance to receive updates."""
+        self.gui = gui
+
+    def __len__(self) -> int:  # pragma: no cover - trivial
+        return len(self.queue)

--- a/modules/discord.py
+++ b/modules/discord.py
@@ -9,31 +9,35 @@ except Exception:  # pragma: no cover - library may be missing
 
 from .catch import CatchMemory
 
+
 class RequestBot(discord.Client):
-    def __init__(self, memory: CatchMemory, **kwargs):
+    def __init__(self, memory: CatchMemory, handler, **kwargs):
         super().__init__(**kwargs)
         self.memory = memory
+        self.handler = handler
 
     async def on_message(self, message):
         if message.author == self.user:
             return
-        if message.content.startswith('!req'):
-            content = message.content[4:].strip()
-            self.memory.remember(message.author.name, content)
+        content = message.content
+        if content.startswith('!req'):
+            req_text = content[4:].strip()
+            self.memory.remember(message.author.name, req_text)
             await message.channel.send("Request noted.")
+        await self.handler(message.author.name, content)
 
-async def run_bot(token: str, memory: CatchMemory):
+async def run_bot(token: str, memory: CatchMemory, handler):
     if discord is None:
         print("discord.py not installed; bot will not run.")
         return
-    bot = RequestBot(memory=memory, intents=discord.Intents.default())
+    bot = RequestBot(memory=memory, handler=handler, intents=discord.Intents.default())
     try:
         await bot.start(token)
     except Exception as e:
         print(f"Discord bot failed: {e}")
 
-def start_bot(token: str, memory: CatchMemory):
+def start_bot(token: str, memory: CatchMemory, handler):
     if not token or token == 'YOUR_DISCORD_TOKEN':
         print("Discord token missing; bot not started.")
         return
-    asyncio.run(run_bot(token, memory))
+    asyncio.run(run_bot(token, memory, handler))

--- a/modules/gui.py
+++ b/modules/gui.py
@@ -1,45 +1,79 @@
 """GUI module for displaying system status."""
 
 import threading
+import time
 
 try:
     import tkinter as tk
+    from tkinter import ttk
 except Exception:  # pragma: no cover - GUI may not be available
     tk = None
+    ttk = None
 
 import psutil
 
-class SystemGUI:
-    """Simple Tkinter GUI showing system stats."""
 
-    def __init__(self, refresh_ms: int = 1000):
+class SystemGUI:
+    """Tkinter GUI showing system stats and message activity."""
+
+    def __init__(self, memory, refresh_ms: int = 1000):
         self.refresh_ms = refresh_ms
+        self.memory = memory
         self.root = None
         self.labels = {}
+        self.queue_bar = None
+        self.queue_label = None
+        self.messages_box = None
+        self.chaos_box = None
+        self.start_time = time.time()
 
+    # ------------------------------------------------------------------
     def _create_widgets(self):
-        stats = ["CPU", "Memory", "Disk", "GPU"]
+        stats = ["CPU", "Memory", "Disk", "GPU", "Uptime"]
         for stat in stats:
             label = tk.Label(self.root, text=f"{stat}: N/A")
             label.pack()
             self.labels[stat] = label
 
+        tk.Label(self.root, text="Messages").pack()
+        self.messages_box = tk.Text(self.root, height=8, state="disabled")
+        self.messages_box.pack(fill="both", expand=True)
+
+        self.queue_bar = ttk.Progressbar(self.root, maximum=self.memory.capacity)
+        self.queue_bar.pack(fill="x")
+        self.queue_label = tk.Label(self.root, text=f"Queue: 0/{self.memory.capacity}")
+        self.queue_label.pack()
+
+        tk.Label(self.root, text="Chaos").pack()
+        self.chaos_box = tk.Text(self.root, height=8, state="disabled")
+        self.chaos_box.pack(fill="both", expand=True)
+
+    # ------------------------------------------------------------------
     def _update_stats(self):
         try:
             cpu = psutil.cpu_percent(interval=None)
             mem = psutil.virtual_memory().percent
             disk = psutil.disk_usage('/').percent
             gpu = self._get_gpu_usage()
+            uptime = int(time.time() - self.start_time)
+            queue_len = len(self.memory)
+
             self.labels["CPU"].config(text=f"CPU: {cpu}%")
             self.labels["Memory"].config(text=f"Memory: {mem}%")
             self.labels["Disk"].config(text=f"Disk: {disk}%")
             self.labels["GPU"].config(text=f"GPU: {gpu}")
+            self.labels["Uptime"].config(text=f"Uptime: {uptime}s")
+            if self.queue_bar is not None:
+                self.queue_bar['value'] = queue_len
+            if self.queue_label is not None:
+                self.queue_label.config(text=f"Queue: {queue_len}/{self.memory.capacity}")
         except Exception as e:  # pragma: no cover
             print(f"GUI update failed: {e}")
         finally:
             if self.root:
                 self.root.after(self.refresh_ms, self._update_stats)
 
+    # ------------------------------------------------------------------
     @staticmethod
     def _get_gpu_usage():
         try:
@@ -51,6 +85,24 @@ class SystemGUI:
             return "N/A"
         return "N/A"
 
+    # ------------------------------------------------------------------
+    def display_message(self, entry):
+        if not self.messages_box:
+            return
+        self.messages_box.configure(state="normal")
+        self.messages_box.insert(tk.END, f"{entry['user']}: {entry['message']}\n")
+        self.messages_box.see(tk.END)
+        self.messages_box.configure(state="disabled")
+
+    def log_event(self, text: str) -> None:
+        if not self.chaos_box:
+            return
+        self.chaos_box.configure(state="normal")
+        self.chaos_box.insert(tk.END, text + "\n")
+        self.chaos_box.see(tk.END)
+        self.chaos_box.configure(state="disabled")
+
+    # ------------------------------------------------------------------
     def run(self):
         if tk is None:
             print("Tkinter not available; GUI will not start.")

--- a/modules/reflect.py
+++ b/modules/reflect.py
@@ -1,0 +1,12 @@
+"""Generate a brief reflection about a user's message using a local LLM."""
+
+from .llm import LocalLLM
+
+
+def reflect(user: str, message: str, llm: LocalLLM) -> str:
+    """Return a short reflection about why the user asked something."""
+    prompt = (
+        f"Consider why user '{user}' said: '{message}'. "
+        "Respond succinctly in ~30 tokens."
+    )
+    return llm.generate(prompt)


### PR DESCRIPTION
## Summary
- add queue-based CatchMemory with GUI hooks
- forward all Discord messages to processing pipeline and log requests
- introduce chaos-aware GUI with system stats and queue progress
- add reflection module and wire into main service

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python main.py --no-gui --test`


------
https://chatgpt.com/codex/tasks/task_e_68b0ac7c59f4832d89312db5bccad0c1