### PR TITLE
feat: use explicit database name

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,14 +7,17 @@
 ## Suggestions
 - Consider adding comprehensive unit tests for each module.
 - Implement full reflection and long-term memory modules.
+- Introduce graceful shutdown for services and database connections.
 
 ## Progress
 ### Completed
 - Added GUI queue display and chaos log.
 - Discord bot now forwards all messages for analysis.
+- Database connection respects configuration-defined database name.
 
 ### In Progress
-- Integrating real LLM models and database storage.
+- Integrating real LLM models and refining database storage.
 
 ### Next Steps
 - Expand engagement logic and persistence once LLM integration stabilizes.
+- Add unit tests for database and engagement modules.

--- a/engage/database.py
+++ b/engage/database.py
@@ -1,6 +1,6 @@
 """MongoDB logging utilities."""
 
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 try:
     from pymongo import MongoClient
@@ -8,7 +8,15 @@ except Exception:  # pragma: no cover
     MongoClient = None
 
 class Database:
-    def __init__(self, uri: str):
+    """Simple wrapper around :class:`pymongo.MongoClient`.
+
+    The database name can be provided separately from the URI so that a
+    generic connection string like ``mongodb://localhost:27017`` may be
+    used.  If ``name`` is omitted the client will attempt to use the
+    default database from the URI.
+    """
+
+    def __init__(self, uri: str, name: Optional[str] = None):
         self.client = None
         self.db = None
         if MongoClient is None:
@@ -16,7 +24,7 @@ class Database:
             return
         try:
             self.client = MongoClient(uri, serverSelectionTimeoutMS=2000)
-            self.db = self.client.get_default_database()
+            self.db = self.client[name] if name else self.client.get_default_database()
             self.client.admin.command('ping')
             print("Connected to MongoDB.")
         except Exception as e:

--- a/main.py
+++ b/main.py
@@ -20,7 +20,8 @@ from engage.database import Database
 
 def start_services(config):
     memory = CatchMemory()
-    db = Database(config["database"]["uri"])
+    db_cfg = config["database"]
+    db = Database(db_cfg["uri"], db_cfg.get("name"))
 
     ports = config["ports"]["dispatch"]
 


### PR DESCRIPTION
## Summary
- allow Database to select DB by explicit name
- wire main service configuration to new Database signature
- note database capability in agent instructions

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python main.py --no-gui --test`


------
https://chatgpt.com/codex/tasks/task_e_68b0adbcba30832daaa79598e32ae8f2