### PR TITLE
Introduce self-state placeholder and improve engagement logic

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,16 +8,20 @@
 - Consider adding comprehensive unit tests for each module.
 - Implement full reflection and long-term memory modules.
 - Introduce graceful shutdown for services and database connections.
+- Develop comprehensive self-state monitoring to inform engagement decisions.
 
 ## Progress
 ### Completed
 - Added GUI queue display and chaos log.
 - Discord bot now forwards all messages for analysis.
 - Database connection respects configuration-defined database name.
+- Placeholder self-state module integrated into engagement logic.
 
 ### In Progress
 - Integrating real LLM models and refining database storage.
+- Refining engagement logic with self-state insights.
 
 ### Next Steps
 - Expand engagement logic and persistence once LLM integration stabilizes.
 - Add unit tests for database and engagement modules.
+- Implement full self-state tracking and resource-based response control.

--- a/engage/engagement.py
+++ b/engage/engagement.py
@@ -3,10 +3,18 @@
 from datetime import datetime
 
 from .database import Database
+from .self_state import is_available
 
 def should_respond(user: str, message: str, intent: str, tone: str) -> bool:
-    """Placeholder decision logic."""
-    return True  # self state module placeholder
+    """Return whether the system should answer a user message.
+
+    The decision currently checks a placeholder self-state indicator and
+    ignores empty messages.  The :mod:`self_state` module can be expanded
+    in the future to provide nuanced behaviour.
+    """
+    if not message.strip():
+        return False
+    return is_available()
 
 def log_interaction(db: Database, user: str, message: str, intent: str, tone: str):
     record = {

--- a/engage/self_state.py
+++ b/engage/self_state.py
@@ -1,0 +1,10 @@
+"""Placeholder self state module."""
+
+
+def is_available() -> bool:
+    """Return whether the system is in a state to respond.
+
+    This placeholder always returns ``True`` but can be expanded to check
+    real runtime conditions such as resource usage or maintenance mode.
+    """
+    return True

--- a/modules/discord.py
+++ b/modules/discord.py
@@ -10,21 +10,28 @@ except Exception:  # pragma: no cover - library may be missing
 from .catch import CatchMemory
 
 
-class RequestBot(discord.Client):
-    def __init__(self, memory: CatchMemory, handler, **kwargs):
-        super().__init__(**kwargs)
-        self.memory = memory
-        self.handler = handler
+if discord is not None:
+    class RequestBot(discord.Client):
+        """Listen for messages and forward them for processing."""
 
-    async def on_message(self, message):
-        if message.author == self.user:
-            return
-        content = message.content
-        if content.startswith('!req'):
-            req_text = content[4:].strip()
-            self.memory.remember(message.author.name, req_text)
-            await message.channel.send("Request noted.")
-        await self.handler(message.author.name, content)
+        def __init__(self, memory: CatchMemory, handler, **kwargs):
+            super().__init__(**kwargs)
+            self.memory = memory
+            self.handler = handler
+
+        async def on_message(self, message):
+            if message.author == self.user:
+                return
+            content = message.content
+            if content.startswith('!req'):
+                req_text = content[4:].strip()
+                self.memory.remember(message.author.name, req_text)
+                await message.channel.send("Request noted.")
+            await self.handler(message.author.name, content)
+else:  # pragma: no cover - executed only when discord.py missing
+    class RequestBot:  # type: ignore
+        def __init__(self, *_, **__):
+            raise RuntimeError("discord.py not installed")
 
 async def run_bot(token: str, memory: CatchMemory, handler):
     if discord is None:


### PR DESCRIPTION
## Summary
- Add `self_state` module and integrate with engagement checks
- Make Discord bot module resilient to missing `discord.py`
- Document progress and next steps in AGENTS.md

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python main.py --no-gui --test`


------
https://chatgpt.com/codex/tasks/task_e_68b0ae847cf8832da1d0f4a7ba899346