### PR TITLE
Add resource-aware self-state and fix Discord intents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,16 +8,21 @@
 - Consider adding comprehensive unit tests for each module.
 - Implement full reflection and long-term memory modules.
 - Introduce graceful shutdown for services and database connections.
+- Develop comprehensive self-state monitoring to inform engagement decisions.
+- Parameterize self-state thresholds in configuration.
 
 ## Progress
 ### Completed
 - Added GUI queue display and chaos log.
 - Discord bot now forwards all messages for analysis.
 - Database connection respects configuration-defined database name.
+- Self-state checks CPU/memory usage and maintenance mode to gate engagement.
 
 ### In Progress
 - Integrating real LLM models and refining database storage.
+- Refining engagement logic with self-state insights.
 
 ### Next Steps
 - Expand engagement logic and persistence once LLM integration stabilizes.
 - Add unit tests for database and engagement modules.
+- Implement full self-state tracking and resource-based response control.

--- a/config.json
+++ b/config.json
@@ -1,5 +1,6 @@
 {
   "discord_token": "YOUR_DISCORD_TOKEN",
+  "maintenance": false,
   "ports": {
     "dispatch": [3535, 3536, 3537]
   },

--- a/engage/engagement.py
+++ b/engage/engagement.py
@@ -3,10 +3,18 @@
 from datetime import datetime
 
 from .database import Database
+from .self_state import is_available
 
 def should_respond(user: str, message: str, intent: str, tone: str) -> bool:
-    """Placeholder decision logic."""
-    return True  # self state module placeholder
+    """Return whether the system should answer a user message.
+
+    The decision checks runtime self-state information and ignores empty
+    messages.  The :mod:`self_state` module may later provide nuanced
+    behaviour.
+    """
+    if not message.strip():
+        return False
+    return is_available()
 
 def log_interaction(db: Database, user: str, message: str, intent: str, tone: str):
     record = {

--- a/engage/self_state.py
+++ b/engage/self_state.py
@@ -1,0 +1,38 @@
+"""Lightweight system self‑awareness checks."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import psutil
+
+_CPU_LIMIT = 90  # percent
+_MEM_LIMIT = 90  # percent
+_CONFIG = Path("config.json")
+
+
+def _maintenance_mode() -> bool:
+    if not _CONFIG.exists():
+        return False
+    try:
+        with _CONFIG.open() as fh:
+            cfg = json.load(fh)
+        return bool(cfg.get("maintenance"))
+    except Exception:
+        return False
+
+
+def is_available() -> bool:
+    """Return whether the system is in a state to respond.
+
+    The check currently considers a configurable maintenance flag as well as
+    CPU and memory utilisation thresholds.
+    """
+
+    if _maintenance_mode():
+        return False
+    cpu = psutil.cpu_percent()
+    mem = psutil.virtual_memory().percent
+    return cpu < _CPU_LIMIT and mem < _MEM_LIMIT
+

--- a/modules/discord.py
+++ b/modules/discord.py
@@ -10,27 +10,36 @@ except Exception:  # pragma: no cover - library may be missing
 from .catch import CatchMemory
 
 
-class RequestBot(discord.Client):
-    def __init__(self, memory: CatchMemory, handler, **kwargs):
-        super().__init__(**kwargs)
-        self.memory = memory
-        self.handler = handler
+if discord is not None:
+    class RequestBot(discord.Client):
+        """Listen for messages and forward them for processing."""
 
-    async def on_message(self, message):
-        if message.author == self.user:
-            return
-        content = message.content
-        if content.startswith('!req'):
-            req_text = content[4:].strip()
-            self.memory.remember(message.author.name, req_text)
-            await message.channel.send("Request noted.")
-        await self.handler(message.author.name, content)
+        def __init__(self, memory: CatchMemory, handler, **kwargs):
+            super().__init__(**kwargs)
+            self.memory = memory
+            self.handler = handler
+
+        async def on_message(self, message):
+            if message.author == self.user:
+                return
+            content = message.content
+            if content.startswith('!req'):
+                req_text = content[4:].strip()
+                self.memory.remember(message.author.name, req_text)
+                await message.channel.send("Request noted.")
+            await self.handler(message.author.name, content)
+else:  # pragma: no cover - executed only when discord.py missing
+    class RequestBot:  # type: ignore
+        def __init__(self, *_, **__):
+            raise RuntimeError("discord.py not installed")
 
 async def run_bot(token: str, memory: CatchMemory, handler):
     if discord is None:
         print("discord.py not installed; bot will not run.")
         return
-    bot = RequestBot(memory=memory, handler=handler, intents=discord.Intents.default())
+    intents = discord.Intents.default()
+    intents.message_content = True
+    bot = RequestBot(memory=memory, handler=handler, intents=intents)
     try:
         await bot.start(token)
     except Exception as e:


### PR DESCRIPTION
## Summary
- Monitor CPU, memory, and maintenance mode through a new self-state module
- Allow Discord bot to read message content by enabling the proper intent
- Record maintenance flag in config and document progress in AGENTS.md

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python main.py --no-gui --test`


------
https://chatgpt.com/codex/tasks/task_e_68b0ae847cf8832da1d0f4a7ba899346