### PR TITLE
Add GUI output window and error popups

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,7 @@
 - Introduce graceful shutdown for services and database connections.
 - Develop comprehensive self-state monitoring to inform engagement decisions.
 - Extend self-state metrics to track disk and network pressure.
+- Persist dispatched outputs for auditing and user review.
 
 
 ## Progress
@@ -17,6 +18,8 @@
 - Added GUI queue display and chaos log.
 - Discord bot now forwards all messages for analysis.
 - Database connection respects configuration-defined database name.
+
+- GUI now shows final responses and logs errors via popup message boxes.
 
 - Self-state checks CPU/memory usage and maintenance mode to gate engagement.
 
@@ -32,3 +35,4 @@
 - Expand engagement logic and persistence once LLM integration stabilizes.
 - Add unit tests for database and engagement modules.
 - Implement full self-state tracking and resource-based response control.
+- Store dispatched outputs for later review and improve error recovery.

--- a/main.py
+++ b/main.py
@@ -48,6 +48,7 @@ def start_services(config):
                 dispatch(response, ports)
                 if memory.gui:
                     memory.gui.log_event(f"dispatch:{user}")
+                    memory.gui.display_output(response)
         except Exception as e:  # pragma: no cover
             handle_error(e)
 

--- a/modules/fallback.py
+++ b/modules/fallback.py
@@ -1,4 +1,17 @@
 """Fallback strategies when errors occur."""
 
+try:
+    import tkinter.messagebox as messagebox
+except Exception:  # pragma: no cover - tkinter may be unavailable
+    messagebox = None
+
+
 def handle_error(error: Exception):
-    print(f"Fallback activated: {error}")
+    msg = f"Fallback activated: {error}"
+    if messagebox:
+        try:
+            messagebox.showerror("System Error", msg)
+        except Exception:
+            print(msg)
+    else:
+        print(msg)

--- a/modules/gui.py
+++ b/modules/gui.py
@@ -25,6 +25,7 @@ class SystemGUI:
         self.queue_label = None
         self.messages_box = None
         self.chaos_box = None
+        self.outputs_box = None
         self.start_time = time.time()
 
     # ------------------------------------------------------------------
@@ -47,6 +48,10 @@ class SystemGUI:
         tk.Label(self.root, text="Chaos").pack()
         self.chaos_box = tk.Text(self.root, height=8, state="disabled")
         self.chaos_box.pack(fill="both", expand=True)
+
+        tk.Label(self.root, text="Outputs").pack()
+        self.outputs_box = tk.Text(self.root, height=8, state="disabled")
+        self.outputs_box.pack(fill="both", expand=True)
 
     # ------------------------------------------------------------------
     def _update_stats(self):
@@ -101,6 +106,14 @@ class SystemGUI:
         self.chaos_box.insert(tk.END, text + "\n")
         self.chaos_box.see(tk.END)
         self.chaos_box.configure(state="disabled")
+
+    def display_output(self, text: str) -> None:
+        if not self.outputs_box:
+            return
+        self.outputs_box.configure(state="normal")
+        self.outputs_box.insert(tk.END, text + "\n")
+        self.outputs_box.see(tk.END)
+        self.outputs_box.configure(state="disabled")
 
     # ------------------------------------------------------------------
     def run(self):


### PR DESCRIPTION
## Summary
- display dispatched responses in a new GUI "Outputs" pane
- surface errors via Tk message boxes when available
- document new feature and follow-up work in AGENTS instructions

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install -r req.txt`
- `python main.py --no-gui --test`


------
https://chatgpt.com/codex/tasks/task_e_68b0b2302ab0832d9e3bbc8114161871