### PR TITLE
feat: add external reflection service

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,8 @@
 
 - Enhance Discord message sanitization and request auditing.
 
+- Add retries and timeout handling for external reflection service.
+
 
 ## Progress
 ### Completed

--- a/agent.dm
+++ b/agent.dm
@@ -2,13 +2,17 @@
 
 ## Done
 - Implemented message sanitization and improved !req command handling in the Discord bot.
+- Reflection module now queries local service on port 5150 with graceful fallback.
 
 ## In Progress
 - Integrating real LLM models and refining database storage.
+- Refining engagement logic with self-state insights.
 
 ## Suggestions
 - Add unit tests for Discord bot message sanitization.
 - Enhance request logging and auditing.
+- Add retries and metrics for reflection service.
 
 ## Completed Summary
 - Discord bot sanitizes messages and routes them to intent and emotion analysis.
+- Reflection module falls back to placeholder when service unavailable.

--- a/modules/reflect.py
+++ b/modules/reflect.py
@@ -2,6 +2,32 @@
 
 from .llm import LocalLLM
 
+try:
+    import requests
+except Exception:  # pragma: no cover - requests may be missing at runtime
+    requests = None
+
+
+REFLECT_URL = "http://localhost:5150/api/v1/generate"
+
+
+def _query_service(prompt: str) -> str:
+    """Query the external reflection service if available."""
+    if not requests:
+        return ""
+    try:
+        resp = requests.post(
+            REFLECT_URL,
+            json={"prompt": prompt, "max_tokens": 64},
+            timeout=5,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        return data.get("text") or data.get("response") or ""
+    except Exception as e:  # pragma: no cover - network issues
+        print(f"Reflection service error: {e}")
+        return ""
+
 
 def reflect(user: str, message: str, llm: LocalLLM) -> str:
     """Return a short reflection about why the user asked something."""
@@ -9,4 +35,7 @@ def reflect(user: str, message: str, llm: LocalLLM) -> str:
         f"Consider why user '{user}' said: '{message}'. "
         "Respond succinctly in ~30 tokens."
     )
+    response = _query_service(prompt)
+    if response:
+        return response
     return llm.generate(prompt)

--- a/req.txt
+++ b/req.txt
@@ -1,3 +1,4 @@
 psutil
 discord.py
 pymongo
+requests


### PR DESCRIPTION
## Summary
- query external reflection service on port 5150 with graceful fallback
- track new dependency in requirements
- document follow-up ideas for reflection service

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python main.py --no-gui --test`


------
https://chatgpt.com/codex/tasks/task_e_68b0f6bda7e0832db4dcd2eebf95cfc7