### PR TITLE
Centralize runtime configuration and add TCP listener

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,7 +37,7 @@
 - Installer upgrades pip and requirements; main runner validates config and optional Discord token.
 - GUI uses dark glitchcore theme with neon accents.
 - README documents multi-machine setup.
-
+- Configuration-driven settings consolidated; added remote listener and MongoDB installer script.
 
 ### In Progress
 - Integrating real LLM models and refining database storage.
@@ -48,3 +48,4 @@
 - Add unit tests for database and engagement modules.
 - Implement full self-state tracking and resource-based response control.
 - Store dispatched outputs for later review and improve error recovery.
+- Validate configuration file and handle missing keys gracefully.

--- a/agent.dm
+++ b/agent.dm
@@ -7,6 +7,7 @@
 - Main runner validates configuration and starts Discord bot only when a token is present.
 - GUI styled with dark glitchcore theme.
 - README explains multi-machine setup.
+- Config-driven settings consolidated; added remote listener and MongoDB install script.
 
 ## In Progress
 - Integrating real LLM models and refining database storage.
@@ -17,8 +18,10 @@
 - Enhance request logging and auditing.
 - Add retries and metrics for reflection service.
 - Automate distributed deployment scripts.
+- Validate configuration file for required keys.
 
 ## Completed Summary
 - Discord bot sanitizes messages and routes them to intent and emotion analysis.
 - Reflection module falls back to placeholder when service unavailable.
 - Installer and main runner hardened; GUI themed; documentation expanded.
+- All runtime settings centralized in config; listener and DB installer introduced.

--- a/config.json
+++ b/config.json
@@ -1,11 +1,36 @@
 {
   "discord_token": "YOUR_DISCORD_TOKEN",
   "maintenance": false,
-  "ports": {
-    "dispatch": [3535, 3536, 3537]
+  "dispatch": {
+    "host": "127.0.0.1",
+    "ports": [3535, 3536, 3537]
+  },
+  "listener": {
+    "host": "0.0.0.0",
+    "ports": [3535, 3536, 3537]
   },
   "database": {
     "uri": "mongodb://localhost:27017",
-    "name": "engagement"
+    "name": "engagement",
+    "timeout_ms": 2000
+  },
+  "catch": {
+    "capacity": 1000
+  },
+  "self_state": {
+    "cpu_limit": 90,
+    "mem_limit": 90
+  },
+  "reflection": {
+    "url": "http://localhost:5150/api/v1/generate",
+    "timeout": 5,
+    "max_tokens": 64
+  },
+  "llm": {
+    "intent_model": "X:/0Rcore/IntentEmotion/BERT-tiny-emotion-intent",
+    "emotion_model": "X:/0Rcore/IntentEmotion/BERT-tiny-emotion-intent",
+    "thought_model": "X:/0Rcore/Rmodel/Phi-3-mini-4k-instruct-q4.gguf",
+    "reflect_model": "X:/0Rcore/Rmodel/Phi-3-mini-4k-instruct-q4.gguf",
+    "runner": "X:/0Rcore/bin/koboldcpp"
   }
 }

--- a/engage/database.py
+++ b/engage/database.py
@@ -16,14 +16,14 @@ class Database:
     default database from the URI.
     """
 
-    def __init__(self, uri: str, name: Optional[str] = None):
+    def __init__(self, uri: str, name: Optional[str] = None, timeout_ms: Optional[int] = None):
         self.client = None
         self.db = None
         if MongoClient is None:
             print("pymongo not installed; database disabled.")
             return
         try:
-            self.client = MongoClient(uri, serverSelectionTimeoutMS=2000)
+            self.client = MongoClient(uri, serverSelectionTimeoutMS=timeout_ms)
             self.db = self.client[name] if name else self.client.get_default_database()
             self.client.admin.command('ping')
             print("Connected to MongoDB.")

--- a/engage/self_state.py
+++ b/engage/self_state.py
@@ -8,9 +8,27 @@ from pathlib import Path
 
 import psutil
 
-_CPU_LIMIT = 90  # percent
-_MEM_LIMIT = 90  # percent
+_DEFAULT_CPU_LIMIT = 90  # percent
+_DEFAULT_MEM_LIMIT = 90  # percent
 _CONFIG = Path("config.json")
+
+
+def _load_limits():
+    if not _CONFIG.exists():
+        return _DEFAULT_CPU_LIMIT, _DEFAULT_MEM_LIMIT
+    try:
+        with _CONFIG.open() as fh:
+            cfg = json.load(fh)
+        limits = cfg.get("self_state", {})
+        return (
+            limits.get("cpu_limit", _DEFAULT_CPU_LIMIT),
+            limits.get("mem_limit", _DEFAULT_MEM_LIMIT),
+        )
+    except Exception:
+        return _DEFAULT_CPU_LIMIT, _DEFAULT_MEM_LIMIT
+
+
+_CPU_LIMIT, _MEM_LIMIT = _load_limits()
 
 
 def _maintenance_mode() -> bool:

--- a/installDB.bat
+++ b/installDB.bat
@@ -1,0 +1,17 @@
+@echo off
+SETLOCAL
+
+REM Download and install MongoDB Server
+powershell -Command "Invoke-WebRequest https://fastdl.mongodb.org/windows/mongodb-windows-x86_64-latest-signed.msi -OutFile mongodb.msi"
+msiexec /qn /i mongodb.msi
+
+REM Download and install MongoDB Compass
+powershell -Command "Invoke-WebRequest https://downloads.mongodb.com/compass/mongodb-compass-latest-win32-x64.exe -OutFile compass.exe"
+start /wait compass.exe /S
+
+REM Configure database according to config.json
+for /f "delims=" %%A in ('powershell -NoProfile -Command "(Get-Content 'config.json' | ConvertFrom-Json).database.uri"') do set DBURI=%%A
+for /f "delims=" %%A in ('powershell -NoProfile -Command "(Get-Content 'config.json' | ConvertFrom-Json).database.name"') do set DBNAME=%%A
+mongosh %DBURI% --eval "db.getSiblingDB('%DBNAME%').createCollection('logs')"
+
+ENDLOCAL

--- a/listener.py
+++ b/listener.py
@@ -1,0 +1,49 @@
+"""Simple TCP listener acknowledging dispatched messages."""
+
+import json
+import socket
+import threading
+from pathlib import Path
+
+
+def _handle(conn: socket.socket):
+    try:
+        data = conn.recv(4096)
+        if data:
+            conn.sendall(b"ACK")
+        else:
+            conn.sendall(b"ERR")
+    except Exception as e:  # pragma: no cover - network errors
+        try:
+            conn.sendall(f"ERR:{e}".encode())
+        except Exception:
+            pass
+    finally:
+        conn.close()
+
+
+def _serve(port: int, host: str):
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind((host, port))
+        s.listen()
+        while True:
+            conn, _ = s.accept()
+            threading.Thread(target=_handle, args=(conn,), daemon=True).start()
+
+
+def main():
+    cfg = json.loads(Path("config.json").read_text())
+    listener_cfg = cfg.get("listener", {})
+    host = listener_cfg.get("host", "0.0.0.0")
+    ports = listener_cfg.get("ports", [])
+    threads = []
+    for port in ports:
+        t = threading.Thread(target=_serve, args=(port, host), daemon=True)
+        t.start()
+        threads.append(t)
+    for t in threads:
+        t.join()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/modules/catch.py
+++ b/modules/catch.py
@@ -13,7 +13,7 @@ from typing import Any, Dict, List, Optional
 class CatchMemory:
     """In-memory storage for short-lived data."""
 
-    def __init__(self, capacity: int = 1000):
+    def __init__(self, capacity: int):
         self.store: Dict[str, Any] = {}
         self.queue: List[Dict[str, Any]] = []
         self.capacity = capacity

--- a/modules/dispatch.py
+++ b/modules/dispatch.py
@@ -3,11 +3,16 @@
 import socket
 from typing import Iterable
 
-def dispatch(message: str, ports: Iterable[int], host: str = 'localhost'):
+
+def dispatch(message: str, ports: Iterable[int], host: str) -> None:
+    """Send ``message`` to each ``port`` on ``host`` and report replies."""
+
     for port in ports:
         try:
             with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
                 sock.connect((host, port))
                 sock.sendall(message.encode())
+                response = sock.recv(1024).decode() or ""
+                print(f"Dispatch to {port} reply: {response}")
         except Exception as e:
             print(f"Dispatch to {port} failed: {e}")

--- a/modules/llm.py
+++ b/modules/llm.py
@@ -1,15 +1,19 @@
 """Module for launching and controlling a local LLM."""
 
+from typing import Optional
+
+
 class LocalLLM:
     """Placeholder local LLM controller."""
 
-    def __init__(self):
+    def __init__(self, model_path: Optional[str]):
+        self.model_path = model_path or ""
         self.running = False
 
     def start(self):
         """Start the LLM."""
         self.running = True
-        print("LLM started")
+        print(f"LLM started with model {self.model_path}")
 
     def generate(self, prompt: str) -> str:
         """Return a canned response."""


### PR DESCRIPTION
## Summary
- move all runtime ports, host addresses, timeouts, and model paths into `config.json`
- add TCP listener and update dispatcher to acknowledge responses
- allow MongoDB timeout and self-state limits to be configured
- provide `installDB.bat` for Windows MongoDB server/Compass install

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python main.py --no-gui --test`


------
https://chatgpt.com/codex/tasks/task_e_68b1259fcf50832dba161dd68c9417ef