### PR TITLE
Add configuration fallbacks and listener resilience

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,3 +58,9 @@
 - Partially done: broader configuration validation schema.
 - Next: add unit tests for configuration logic.
 - Estimated completion: 30%
+
+- Done: added config auto-generation and listener fallbacks; documented system fallback behavior.
+- Worked on: strengthening error handling across configuration and listener scripts.
+- Partially done: broader fallback coverage for remaining modules.
+- Next: extend fallbacks to LLM operations and create unit tests.
+- Estimated completion: 35%

--- a/README.md
+++ b/README.md
@@ -32,6 +32,15 @@ Missing keys are automatically populated with sensible defaults and any
 type mismatches are reported at startup.  Every option lives in this single
 configuration file so changes propagate consistently across machines.
 
+## Fallback Behavior
+
+- If `config.json` is missing or contains invalid data a default copy is
+  created automatically so services can still launch.
+- The standalone `listener.py` script uses the same configuration loader and
+  falls back to default host/ports on errors.
+- Optional libraries such as `discord.py`, `pymongo`, `requests` or
+  `tkinter` disable only their respective features when unavailable.
+
 ## Running on Multiple Machines
 
 Each machine should have the repository and configuration file.  On


### PR DESCRIPTION
## Summary
- Auto-create config.json with defaults when missing or invalid
- Rework listener to use shared config loader and handle per-port failures
- Document system-wide fallback behaviors

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python main.py --no-gui --test`


------
https://chatgpt.com/codex/tasks/task_e_68b355dae820832db07c312caef20580