### PR TITLE
Add LLM offline fallback and installer retries

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,7 @@
 
 - Automate multi-machine deployment and configuration validation.
 - Expand configuration validation with type checks and defaults.
+- Provide automated model downloads and checksum validation to ensure LLM availability.
 
 
 ## Progress
@@ -64,3 +65,9 @@
 - Partially done: broader fallback coverage for remaining modules.
 - Next: extend fallbacks to LLM operations and create unit tests.
 - Estimated completion: 35%
+
+- Done: implemented LLM offline mode and per-package installer retries; updated README.
+- Worked on: broader fallback support for model startup and dependency installation.
+- Partially done: automated model retrieval and comprehensive installer logging.
+- Next: add tests for installer fallback and integrate real models.
+- Estimated completion: 40%

--- a/README.md
+++ b/README.md
@@ -40,6 +40,11 @@ configuration file so changes propagate consistently across machines.
   falls back to default host/ports on errors.
 - Optional libraries such as `discord.py`, `pymongo`, `requests` or
   `tkinter` disable only their respective features when unavailable.
+- Dependency installation retries each package individually if the bulk
+  install fails, reducing setup friction on unstable networks.
+- Local LLMs start in an offline mode when their model files are missing; in
+  this state `generate` returns the `llm.offline_response` string from
+  `config.json`.
 
 ## Running on Multiple Machines
 

--- a/config.json
+++ b/config.json
@@ -26,11 +26,12 @@
     "timeout": 5,
     "max_tokens": 64
   },
-  "llm": {
-    "intent_model": "X:/0Rcore/IntentEmotion/BERT-tiny-emotion-intent",
-    "emotion_model": "X:/0Rcore/IntentEmotion/BERT-tiny-emotion-intent",
-    "thought_model": "X:/0Rcore/Rmodel/Phi-3-mini-4k-instruct-q4.gguf",
-    "reflect_model": "X:/0Rcore/Rmodel/Phi-3-mini-4k-instruct-q4.gguf",
-    "runner": "X:/0Rcore/bin/koboldcpp"
-  }
+    "llm": {
+        "intent_model": "X:/0Rcore/IntentEmotion/BERT-tiny-emotion-intent",
+        "emotion_model": "X:/0Rcore/IntentEmotion/BERT-tiny-emotion-intent",
+        "thought_model": "X:/0Rcore/Rmodel/Phi-3-mini-4k-instruct-q4.gguf",
+        "reflect_model": "X:/0Rcore/Rmodel/Phi-3-mini-4k-instruct-q4.gguf",
+        "runner": "X:/0Rcore/bin/koboldcpp",
+        "offline_response": "LLM offline"
+    }
 }

--- a/install.py
+++ b/install.py
@@ -23,8 +23,19 @@ def main() -> None:
     try:
         subprocess.check_call([sys.executable, "-m", "pip", "install", "--upgrade", "pip"])
         subprocess.check_call([sys.executable, "-m", "pip", "install", "-r", str(req_file)])
+        return
     except subprocess.CalledProcessError as exc:  # pragma: no cover - network issues
-        print(f"Dependency installation failed: {exc}")
+        print(f"Bulk dependency installation failed: {exc}")
+
+    # Fallback: attempt installation one package at a time
+    for line in req_file.read_text().splitlines():
+        pkg = line.strip()
+        if not pkg or pkg.startswith("#"):
+            continue
+        try:
+            subprocess.check_call([sys.executable, "-m", "pip", "install", pkg])
+        except subprocess.CalledProcessError as exc:  # pragma: no cover
+            print(f"Failed to install {pkg}: {exc}")
 
 
 if __name__ == "__main__":

--- a/main.py
+++ b/main.py
@@ -41,6 +41,7 @@ DEFAULT_CONFIG: Dict[str, Any] = {
         "thought_model": "X:/0Rcore/Rmodel/Phi-3-mini-4k-instruct-q4.gguf",
         "reflect_model": "X:/0Rcore/Rmodel/Phi-3-mini-4k-instruct-q4.gguf",
         "runner": "X:/0Rcore/bin/koboldcpp",
+        "offline_response": "LLM offline",
     },
 }
 
@@ -121,10 +122,11 @@ def start_services(config: dict) -> CatchMemory:
     llm_cfg = config.get("llm", {})
 
     # Start placeholder LLMs
-    llm_intent = LocalLLM(llm_cfg.get("intent_model"))
-    llm_emotion = LocalLLM(llm_cfg.get("emotion_model"))
-    llm_thoughts = LocalLLM(llm_cfg.get("thought_model"))
-    llm_reflect = LocalLLM(llm_cfg.get("reflect_model"))
+    offline_resp = llm_cfg.get("offline_response", "")
+    llm_intent = LocalLLM(llm_cfg.get("intent_model"), offline_resp)
+    llm_emotion = LocalLLM(llm_cfg.get("emotion_model"), offline_resp)
+    llm_thoughts = LocalLLM(llm_cfg.get("thought_model"), offline_resp)
+    llm_reflect = LocalLLM(llm_cfg.get("reflect_model"), offline_resp)
     for llm in (llm_intent, llm_emotion, llm_thoughts, llm_reflect):
         threading.Thread(target=llm.start, daemon=True).start()
 

--- a/modules/llm.py
+++ b/modules/llm.py
@@ -1,22 +1,41 @@
 """Module for launching and controlling a local LLM."""
 
+from pathlib import Path
 from typing import Optional
 
 
 class LocalLLM:
-    """Placeholder local LLM controller."""
+    """Placeholder local LLM controller with basic fallback behaviour."""
 
-    def __init__(self, model_path: Optional[str]):
+    def __init__(self, model_path: Optional[str], offline_response: str = ""):
         self.model_path = model_path or ""
+        self.offline_response = offline_response
         self.running = False
 
-    def start(self):
-        """Start the LLM."""
-        self.running = True
-        print(f"LLM started with model {self.model_path}")
+    def start(self) -> None:
+        """Start the LLM if the model is available.
+
+        When the model path is missing or startup fails the instance switches to
+        an offline mode and ``generate`` will return the configured fallback
+        response instead of raising errors.
+        """
+
+        try:
+            if self.model_path and not Path(self.model_path).exists():
+                print(f"LLM model not found at {self.model_path}; using offline mode.")
+                return
+            self.running = True
+            print(f"LLM started with model {self.model_path}")
+        except Exception as e:  # pragma: no cover - unforeseen startup errors
+            print(f"LLM start failed ({e}); using offline mode.")
 
     def generate(self, prompt: str) -> str:
-        """Return a canned response."""
+        """Return a canned response or the offline fallback when stopped."""
+
         if not self.running:
-            return ""
-        return f"LLM response to: {prompt}"
+            return self.offline_response
+        try:
+            return f"LLM response to: {prompt}"
+        except Exception as e:  # pragma: no cover - generation errors
+            print(f"LLM generation error ({e}); returning offline response.")
+            return self.offline_response


### PR DESCRIPTION
## Summary
- add offline mode and error handling to LocalLLM
- retry package installation individually when bulk install fails
- document new fallbacks and record progress notes

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python main.py --no-gui --test` *(fails: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68b368781658832da0556cdc243692b7