### PR TITLE
Add service manager with graceful shutdown

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@
 ## Suggestions
 - Consider adding comprehensive unit tests for each module.
 - Implement full reflection and long-term memory modules.
-- Introduce graceful shutdown for services and database connections.
+- Enhance service manager with thread joining and Discord bot cleanup.
 - Develop comprehensive self-state monitoring to inform engagement decisions.
 - Extend self-state metrics to track disk and network pressure.
 - Persist dispatched outputs for auditing and user review.
@@ -71,3 +71,9 @@
 - Partially done: automated model retrieval and comprehensive installer logging.
 - Next: add tests for installer fallback and integrate real models.
 - Estimated completion: 40%
+
+- Done: added service manager with graceful shutdown for LLMs and database; documented shutdown.
+- Worked on: background service cleanup and README instructions.
+- Partially done: explicit thread joins and Discord bot shutdown.
+- Next: ensure all threads terminate cleanly and add tests for shutdown logic.
+- Estimated completion: 45%

--- a/README.md
+++ b/README.md
@@ -70,6 +70,11 @@ To run a lightweight smoke test without launching the GUI:
 python main.py --no-gui --test
 ```
 
+## Shutdown
+
+Press `Ctrl+C` in the terminal to terminate the services. Database
+connections close and background LLM helpers stop cleanly.
+
 ## License
 
 This project is provided as-is without a specific license.

--- a/engage/database.py
+++ b/engage/database.py
@@ -38,3 +38,13 @@ class Database:
             self.db.logs.insert_one(record)
         except Exception as e:
             print(f"Logging failed: {e}")
+
+    def close(self) -> None:
+        """Close the database connection if open."""
+
+        if self.client:
+            try:
+                self.client.close()
+            finally:
+                self.client = None
+                self.db = None

--- a/modules/llm.py
+++ b/modules/llm.py
@@ -39,3 +39,10 @@ class LocalLLM:
         except Exception as e:  # pragma: no cover - generation errors
             print(f"LLM generation error ({e}); returning offline response.")
             return self.offline_response
+
+    def stop(self) -> None:
+        """Stop the LLM and prevent further generation."""
+
+        if self.running:
+            self.running = False
+            print(f"LLM at {self.model_path} stopped")


### PR DESCRIPTION
## Summary
- add `Services` container to coordinate memory, database, and LLM helpers
- allow `LocalLLM` and `Database` to stop and close cleanly
- document shutdown procedure in README and track progress in AGENTS notes

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python main.py --no-gui --test`

------
https://chatgpt.com/codex/tasks/task_e_68b3886b6aa8832db875ea49d8ab1178